### PR TITLE
Changes from background agent bc-3f9cc7be-5bbc-48ce-922a-cf0f610099ee

### DIFF
--- a/main/resources/templates/account/my-bills.html
+++ b/main/resources/templates/account/my-bills.html
@@ -6,7 +6,7 @@
     <title>Moji Računi</title>
 </head>
 <body>
-<div th:block="layout:fragment='content'">
+<div layout:fragment="content">
     <!-- Welcome Message -->
     <div class="alert alert-info" role="alert">
         <i class="bi bi-info-circle"></i>

--- a/main/resources/templates/dashboard/index.html
+++ b/main/resources/templates/dashboard/index.html
@@ -6,7 +6,7 @@
     <title>Dashboard</title>
 </head>
 <body>
-<div th:block="layout:fragment='content'">
+<div layout:fragment="content">
     <!-- Statistics Cards -->
     <div class="row mb-4">
         <!-- Korisnici -->
@@ -188,7 +188,7 @@
     </div>
 </div>
 
-<div th:block="layout:fragment='scripts'">
+<div layout:fragment="scripts">
     <style>
         .border-left-primary {
             border-left: 0.25rem solid #4e73df !important;

--- a/main/resources/templates/layout/main.html
+++ b/main/resources/templates/layout/main.html
@@ -188,7 +188,7 @@
                 </div>
 
                 <!-- Page Content -->
-                <div th:block="layout:fragment='content'">
+                <div layout:fragment="content">
                     <p>Content goes here</p>
                 </div>
             </main>
@@ -198,6 +198,6 @@
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <!-- Custom JS -->
-    <div th:block="layout:fragment='scripts'"></div>
+    <div layout:fragment="scripts"></div>
 </body>
 </html>

--- a/main/resources/templates/users/form.html
+++ b/main/resources/templates/users/form.html
@@ -6,7 +6,7 @@
     <title>Korisnik</title>
 </head>
 <body>
-<div th:block="layout:fragment='content'">
+<div layout:fragment="content">
     <!-- Navigation -->
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">

--- a/main/resources/templates/users/list.html
+++ b/main/resources/templates/users/list.html
@@ -6,7 +6,7 @@
     <title>Korisnici</title>
 </head>
 <body>
-<div th:block="layout:fragment='content'">
+<div layout:fragment="content">
     <!-- Page Actions -->
     <div class="d-flex justify-content-between align-items-center mb-3">
         <h1 class="h3 mb-0">Korisnici</h1>

--- a/main/resources/templates/users/view.html
+++ b/main/resources/templates/users/view.html
@@ -6,7 +6,7 @@
     <title>Pregled Korisnika</title>
 </head>
 <body>
-<div th:block="layout:fragment='content'">
+<div layout:fragment="content">
     <!-- Navigation -->
     <nav aria-label="breadcrumb">
         <ol class="breadcrumb">


### PR DESCRIPTION
Corrects Thymeleaf `layout:fragment` syntax to resolve template parsing errors.

The previous syntax `th:block="layout:fragment='content'"` was an incorrect combination of `th:block` and the `layout:fragment` attribute, causing parsing exceptions. This PR updates all affected templates to use the correct `layout:fragment="content"` directly.

---
<a href="https://cursor.com/background-agent?bcId=bc-3f9cc7be-5bbc-48ce-922a-cf0f610099ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f9cc7be-5bbc-48ce-922a-cf0f610099ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

