### PR TITLE
Check why menus are not opening

### DIFF
--- a/main/java/com/vodovod/controller/BillsController.java
+++ b/main/java/com/vodovod/controller/BillsController.java
@@ -1,0 +1,17 @@
+package com.vodovod.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/bills")
+public class BillsController {
+
+    @GetMapping
+    public String index(Model model) {
+        model.addAttribute("pageTitle", "Računi");
+        return "bills/index";
+    }
+}

--- a/main/java/com/vodovod/controller/PaymentsController.java
+++ b/main/java/com/vodovod/controller/PaymentsController.java
@@ -1,0 +1,23 @@
+package com.vodovod.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/payments")
+public class PaymentsController {
+
+    @GetMapping
+    public String index(Model model) {
+        model.addAttribute("pageTitle", "Plaćanja");
+        return "payments/index";
+    }
+    
+    @GetMapping("/new")
+    public String newPayment(Model model) {
+        model.addAttribute("pageTitle", "Novo plaćanje");
+        return "payments/new";
+    }
+}

--- a/main/java/com/vodovod/controller/ReadingsController.java
+++ b/main/java/com/vodovod/controller/ReadingsController.java
@@ -1,0 +1,23 @@
+package com.vodovod.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/readings")
+public class ReadingsController {
+
+    @GetMapping
+    public String index(Model model) {
+        model.addAttribute("pageTitle", "Očitanja");
+        return "readings/index";
+    }
+    
+    @GetMapping("/new")
+    public String newReading(Model model) {
+        model.addAttribute("pageTitle", "Novo očitanje");
+        return "readings/new";
+    }
+}

--- a/main/java/com/vodovod/controller/SettingsController.java
+++ b/main/java/com/vodovod/controller/SettingsController.java
@@ -1,0 +1,17 @@
+package com.vodovod.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/settings")
+public class SettingsController {
+
+    @GetMapping
+    public String index(Model model) {
+        model.addAttribute("pageTitle", "Postavke");
+        return "settings/index";
+    }
+}

--- a/main/resources/templates/bills/index.html
+++ b/main/resources/templates/bills/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title>Računi</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <!-- Page Heading -->
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800">Računi</h1>
+        <a href="/bills/new" class="btn btn-primary btn-sm">
+            <i class="bi bi-plus-circle"></i> Novi račun
+        </a>
+    </div>
+
+    <!-- Content Row -->
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Pregled računa</h6>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th>Broj računa</th>
+                                    <th>Korisnik</th>
+                                    <th>Datum izdavanja</th>
+                                    <th>Rok plaćanja</th>
+                                    <th>Iznos</th>
+                                    <th>Status</th>
+                                    <th>Akcije</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="7" class="text-center">Nema podataka za prikaz</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/main/resources/templates/payments/index.html
+++ b/main/resources/templates/payments/index.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title>Plaćanja</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <!-- Page Heading -->
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800">Plaćanja</h1>
+        <a href="/payments/new" class="btn btn-primary btn-sm">
+            <i class="bi bi-plus-circle"></i> Novo plaćanje
+        </a>
+    </div>
+
+    <!-- Content Row -->
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Pregled plaćanja</h6>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Broj računa</th>
+                                    <th>Korisnik</th>
+                                    <th>Datum plaćanja</th>
+                                    <th>Iznos</th>
+                                    <th>Način plaćanja</th>
+                                    <th>Status</th>
+                                    <th>Akcije</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="8" class="text-center">Nema podataka za prikaz</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/main/resources/templates/payments/new.html
+++ b/main/resources/templates/payments/new.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title>Novo plaćanje</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <!-- Page Heading -->
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800">Novo plaćanje</h1>
+    </div>
+
+    <!-- Content Row -->
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Unos novog plaćanja</h6>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="/payments/new">
+                        <div class="form-group">
+                            <label for="billId">Račun</label>
+                            <select class="form-control" id="billId" name="billId" required>
+                                <option value="">Odaberite račun</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="paymentDate">Datum plaćanja</label>
+                            <input type="date" class="form-control" id="paymentDate" name="paymentDate" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="amount">Iznos (kn)</label>
+                            <input type="number" class="form-control" id="amount" name="amount" step="0.01" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="paymentMethod">Način plaćanja</label>
+                            <select class="form-control" id="paymentMethod" name="paymentMethod" required>
+                                <option value="">Odaberite način plaćanja</option>
+                                <option value="CASH">Gotovina</option>
+                                <option value="BANK_TRANSFER">Bankovni prijenos</option>
+                                <option value="CARD">Kartica</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="reference">Poziv na broj</label>
+                            <input type="text" class="form-control" id="reference" name="reference">
+                        </div>
+                        <div class="form-group">
+                            <label for="notes">Napomene</label>
+                            <textarea class="form-control" id="notes" name="notes" rows="3"></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Spremi plaćanje</button>
+                        <a href="/payments" class="btn btn-secondary">Odustani</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/main/resources/templates/readings/index.html
+++ b/main/resources/templates/readings/index.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title>Očitanja</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <!-- Page Heading -->
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800">Očitanja</h1>
+        <a href="/readings/new" class="btn btn-primary btn-sm">
+            <i class="bi bi-plus-circle"></i> Novo očitanje
+        </a>
+    </div>
+
+    <!-- Content Row -->
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Pregled očitanja</h6>
+                </div>
+                <div class="card-body">
+                    <div class="table-responsive">
+                        <table class="table table-bordered" id="dataTable" width="100%" cellspacing="0">
+                            <thead>
+                                <tr>
+                                    <th>ID</th>
+                                    <th>Korisnik</th>
+                                    <th>Datum očitanja</th>
+                                    <th>Prethodno stanje</th>
+                                    <th>Novo stanje</th>
+                                    <th>Potrošnja</th>
+                                    <th>Akcije</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td colspan="7" class="text-center">Nema podataka za prikaz</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/main/resources/templates/readings/new.html
+++ b/main/resources/templates/readings/new.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title>Novo očitanje</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <!-- Page Heading -->
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800">Novo očitanje</h1>
+    </div>
+
+    <!-- Content Row -->
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Unos novog očitanja</h6>
+                </div>
+                <div class="card-body">
+                    <form method="post" action="/readings/new">
+                        <div class="form-group">
+                            <label for="userId">Korisnik</label>
+                            <select class="form-control" id="userId" name="userId" required>
+                                <option value="">Odaberite korisnika</option>
+                            </select>
+                        </div>
+                        <div class="form-group">
+                            <label for="readingDate">Datum očitanja</label>
+                            <input type="date" class="form-control" id="readingDate" name="readingDate" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="previousReading">Prethodno stanje (m³)</label>
+                            <input type="number" class="form-control" id="previousReading" name="previousReading" step="0.01" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="currentReading">Novo stanje (m³)</label>
+                            <input type="number" class="form-control" id="currentReading" name="currentReading" step="0.01" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="consumption">Potrošnja (m³)</label>
+                            <input type="number" class="form-control" id="consumption" name="consumption" step="0.01" readonly>
+                        </div>
+                        <div class="form-group">
+                            <label for="notes">Napomene</label>
+                            <textarea class="form-control" id="notes" name="notes" rows="3"></textarea>
+                        </div>
+                        <button type="submit" class="btn btn-primary">Spremi očitanje</button>
+                        <a href="/readings" class="btn btn-secondary">Odustani</a>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/main/resources/templates/settings/index.html
+++ b/main/resources/templates/settings/index.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title>Postavke</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <!-- Page Heading -->
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800">Postavke</h1>
+    </div>
+
+    <!-- Content Row -->
+    <div class="row">
+        <!-- Opće postavke -->
+        <div class="col-lg-6">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Opće postavke</h6>
+                </div>
+                <div class="card-body">
+                    <form>
+                        <div class="form-group">
+                            <label for="companyName">Naziv tvrtke</label>
+                            <input type="text" class="form-control" id="companyName" value="Vodovod d.o.o.">
+                        </div>
+                        <div class="form-group">
+                            <label for="address">Adresa</label>
+                            <input type="text" class="form-control" id="address" value="Ulica 123, 10000 Zagreb">
+                        </div>
+                        <div class="form-group">
+                            <label for="phone">Telefon</label>
+                            <input type="text" class="form-control" id="phone" value="+385 1 234 5678">
+                        </div>
+                        <div class="form-group">
+                            <label for="email">Email</label>
+                            <input type="email" class="form-control" id="email" value="info@vodovod.hr">
+                        </div>
+                        <button type="submit" class="btn btn-primary">Spremi postavke</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Postavke cijena -->
+        <div class="col-lg-6">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Postavke cijena</h6>
+                </div>
+                <div class="card-body">
+                    <form>
+                        <div class="form-group">
+                            <label for="waterPrice">Cijena vode (kn/m³)</label>
+                            <input type="number" class="form-control" id="waterPrice" value="5.50" step="0.01">
+                        </div>
+                        <div class="form-group">
+                            <label for="sewagePrice">Cijena odvodnje (kn/m³)</label>
+                            <input type="number" class="form-control" id="sewagePrice" value="3.50" step="0.01">
+                        </div>
+                        <div class="form-group">
+                            <label for="fixedFee">Fiksna naknada (kn)</label>
+                            <input type="number" class="form-control" id="fixedFee" value="15.00" step="0.01">
+                        </div>
+                        <div class="form-group">
+                            <label for="vat">PDV (%)</label>
+                            <input type="number" class="form-control" id="vat" value="25" step="1">
+                        </div>
+                        <button type="submit" class="btn btn-primary">Spremi cijene</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Ostale postavke -->
+    <div class="row">
+        <div class="col-lg-12">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Ostale postavke</h6>
+                </div>
+                <div class="card-body">
+                    <form>
+                        <div class="form-group">
+                            <label for="paymentDeadline">Rok plaćanja (dana)</label>
+                            <input type="number" class="form-control" id="paymentDeadline" value="15">
+                        </div>
+                        <div class="form-group">
+                            <label for="reminderDays">Podsjetnik prije isteka (dana)</label>
+                            <input type="number" class="form-control" id="reminderDays" value="5">
+                        </div>
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="autoGenerateBills" checked>
+                            <label class="form-check-label" for="autoGenerateBills">
+                                Automatski generiraj račune
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input type="checkbox" class="form-check-input" id="sendEmailNotifications" checked>
+                            <label class="form-check-label" for="sendEmailNotifications">
+                                Šalji email obavijesti
+                            </label>
+                        </div>
+                        <button type="submit" class="btn btn-primary mt-3">Spremi postavke</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Add missing Spring Boot controllers and Thymeleaf templates for `/readings`, `/bills`, `/payments`, and `/settings` routes.

The user reported that menu links for these pages were not opening because the corresponding backend routes and frontend templates were not implemented. This PR resolves the issue by adding the necessary controllers and basic HTML templates to make these pages accessible.

---
<a href="https://cursor.com/background-agent?bcId=bc-809aac23-653a-4e69-9acb-3a948a3ace8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-809aac23-653a-4e69-9acb-3a948a3ace8e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

