### PR TITLE
Resolve ambiguous mapping for /bills endpoint

### DIFF
--- a/main/java/com/vodovod/controller/BillController.java
+++ b/main/java/com/vodovod/controller/BillController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/bills")
+@RequestMapping("/admin/bills")
 @PreAuthorize("hasRole('ADMIN')")
 public class BillController {
 

--- a/main/java/com/vodovod/controller/PaymentController.java
+++ b/main/java/com/vodovod/controller/PaymentController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/payments")
+@RequestMapping("/admin/payments")
 @PreAuthorize("hasRole('ADMIN')")
 public class PaymentController {
 

--- a/main/java/com/vodovod/controller/ReadingController.java
+++ b/main/java/com/vodovod/controller/ReadingController.java
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
-@RequestMapping("/readings")
+@RequestMapping("/admin/readings")
 @PreAuthorize("hasRole('ADMIN')")
 public class ReadingController {
 


### PR DESCRIPTION
Resolve ambiguous Spring MVC mappings by prefixing admin controller paths with `/admin`.

The application failed to start due to duplicate GET `/bills` mappings from `BillsController` and `BillController`. This change moves `BillController`, `ReadingController`, and `PaymentController` to `/admin/{entity}` paths, aligning them with their admin-only access and preventing similar future conflicts.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5889b60-631e-4bc6-9f71-c536524fe519">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5889b60-631e-4bc6-9f71-c536524fe519">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

