### PR TITLE
Update readings and user state

### DIFF
--- a/main/java/com/vodovod/controller/ReadingsController.java
+++ b/main/java/com/vodovod/controller/ReadingsController.java
@@ -36,6 +36,12 @@ public class ReadingsController {
     @GetMapping
     public String index(Model model) {
         model.addAttribute("pageTitle", "Očitanja");
+        model.addAttribute("activeMenu", "readings");
+
+        // Učitaj sva očitanja (najnovija prva)
+        List<MeterReading> readings = meterReadingService.getAllReadings();
+        model.addAttribute("readings", readings);
+
         return "readings/index";
     }
     

--- a/main/java/com/vodovod/service/MeterReadingService.java
+++ b/main/java/com/vodovod/service/MeterReadingService.java
@@ -4,6 +4,7 @@ import com.vodovod.model.MeterReading;
 import com.vodovod.model.User;
 import com.vodovod.repository.MeterReadingRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -90,7 +91,8 @@ public class MeterReadingService {
      * Dohvaća sva očitanja sortirana po datumu
      */
     public List<MeterReading> getAllReadings() {
-        return meterReadingRepository.findAll();
+        // Vraća sva očitanja sortirana po datumu očitanja (najnovija prva)
+        return meterReadingRepository.findAll(Sort.by(Sort.Direction.DESC, "readingDate"));
     }
 
     /**

--- a/main/resources/templates/readings/index.html
+++ b/main/resources/templates/readings/index.html
@@ -37,7 +37,18 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr>
+                                <tr th:each="reading : ${readings}" th:unless="${#lists.isEmpty(readings)}">
+                                    <td th:text="${reading.id}">1</td>
+                                    <td th:text="${reading.user.fullName}">Ime Prezime</td>
+                                    <td th:text="${reading.readingDate}">2023-01-01</td>
+                                    <td th:text="${reading.previousReadingValue}">0.000</td>
+                                    <td th:text="${reading.readingValue}">10.000</td>
+                                    <td th:text="${reading.consumption}">10.000</td>
+                                    <td>
+                                        <!-- Placeholder for future actions (edit/delete) -->
+                                    </td>
+                                </tr>
+                                <tr th:if="${#lists.isEmpty(readings)}">
                                     <td colspan="7" class="text-center">Nema podataka za prikaz</td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
Display all meter readings on page load, sorted by date, and ensure the list refreshes after adding a new reading.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2d4fbf7-4c39-42ce-b3fd-b1830b263528">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e2d4fbf7-4c39-42ce-b3fd-b1830b263528">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

