### PR TITLE
Handle new reading creation and validation

### DIFF
--- a/main/resources/templates/readings/index.html
+++ b/main/resources/templates/readings/index.html
@@ -71,7 +71,7 @@
 </div>
 
 <div layout:fragment="scripts">
-<script>
+<script th:inline="none">
 $(document).ready(function() {
     $('#dataTable').DataTable({
         "language": {

--- a/main/resources/templates/readings/new.html
+++ b/main/resources/templates/readings/new.html
@@ -28,7 +28,7 @@
                     <h6 class="m-0 font-weight-bold text-primary">Unos novog očitanja</h6>
                 </div>
                 <div class="card-body">
-                    <form method="post" action="/readings/new" th:object="${newReadingDTO}">
+                    <form id="newReadingForm" method="post" action="/readings/new" th:object="${newReadingDTO}">
                         <div class="form-group">
                             <label for="userId">Korisnik</label>
                             <select class="form-control" id="userId" name="userId" th:field="*{userId}" required>
@@ -96,6 +96,8 @@ $(document).ready(function() {
     var $lastReadingInfo = $('#lastReadingInfo');
     var $validationMessage = $('#readingValidationMessage');
     var $submitBtn = $('#submitBtn');
+    var $form = $('#newReadingForm');
+    var pendingWarn = null;
 
     // Set today's date as default
     $readingDate.val(new Date().toISOString().split('T')[0]);
@@ -114,6 +116,18 @@ $(document).ready(function() {
     $currentReading.add($readingDate).on('input change', function() {
         calculateConsumption();
         validateReading();
+    });
+
+    // Intercept submit to show warning confirmation if needed
+    $form.on('submit', function(e) {
+        if (pendingWarn) {
+            var proceed = window.confirm(pendingWarn + '\n\nŽelite li svejedno spremiti očitanje?');
+            if (!proceed) {
+                e.preventDefault();
+                return false;
+            }
+            // If proceed, allow default submit to continue
+        }
     });
 
     function loadPreviousReading(userId) {
@@ -179,10 +193,14 @@ $(document).ready(function() {
                 readingDate: readingDate
             }),
             success: function(data) {
+                pendingWarn = null;
                 if (data.valid) {
                     $validationMessage.hide();
                     $submitBtn.prop('disabled', false);
                     $currentReading.removeClass('is-invalid').addClass('is-valid');
+                    if (data.warn && data.warningMessage) {
+                        pendingWarn = data.warningMessage;
+                    }
                 } else {
                     $validationMessage.find('small').text(data.message || 'Neispravno očitanje');
                     $validationMessage.show();


### PR DESCRIPTION
Fixes Thymeleaf parsing error and implements new meter reading form features including consumption deviation warning.

The Thymeleaf error in `readings/index.html` was caused by `[[ 0, "desc" ]]` being parsed as an expression within a script block; disabling inlining resolves this. The new reading features (auto-date, previous reading, validation, and a non-blocking 20% consumption deviation warning) were added to meet specific user requirements for the new entry flow.

---
<a href="https://cursor.com/background-agent?bcId=bc-d123b7a6-5f94-49da-a412-f1479003208e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d123b7a6-5f94-49da-a412-f1479003208e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

