### PR TITLE
Dodaj novo ocitanje bez automatskih provjera

### DIFF
--- a/main/java/com/vodovod/repository/MeterReadingRepository.java
+++ b/main/java/com/vodovod/repository/MeterReadingRepository.java
@@ -18,8 +18,7 @@ public interface MeterReadingRepository extends JpaRepository<MeterReading, Long
     @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user ORDER BY mr.readingDate DESC")
     List<MeterReading> findByUserOrderByReadingDateDescending(User user);
     
-    @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user ORDER BY mr.readingDate DESC LIMIT 1")
-    Optional<MeterReading> findLatestByUser(User user);
+    Optional<MeterReading> findTopByUserOrderByReadingDateDesc(User user);
     
     @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user AND mr.readingDate = :readingDate")
     Optional<MeterReading> findByUserAndReadingDate(User user, LocalDate readingDate);

--- a/main/java/com/vodovod/service/MeterReadingService.java
+++ b/main/java/com/vodovod/service/MeterReadingService.java
@@ -43,7 +43,7 @@ public class MeterReadingService {
      * Dohvaća najnovije očitanje za korisnika
      */
     public Optional<MeterReading> getLatestReadingByUser(User user) {
-        return meterReadingRepository.findLatestByUser(user);
+        return meterReadingRepository.findTopByUserOrderByReadingDateDesc(user);
     }
 
     /**

--- a/main/resources/templates/layout/main.html
+++ b/main/resources/templates/layout/main.html
@@ -7,6 +7,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title th:text="${pageTitle} + ' - Vodovod Management'">Vodovod Management</title>
     
+    <!-- CSRF Meta -->
+    <meta name="_csrf" th:content="${_csrf.token}" />
+    <meta name="_csrf_header" th:content="${_csrf.headerName}" />
+    
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <!-- Bootstrap Icons -->
@@ -195,9 +199,25 @@
         </div>
     </div>
 
+        <!-- jQuery (required for features on some pages) -->
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
     <!-- Bootstrap JS -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+      // Setup CSRF header for all AJAX requests
+      (function() {
+        var token = document.querySelector('meta[name="_csrf"]').getAttribute('content');
+        var header = document.querySelector('meta[name="_csrf_header"]').getAttribute('content');
+        if (window.jQuery && token && header) {
+          $.ajaxSetup({
+            beforeSend: function(xhr) {
+              xhr.setRequestHeader(header, token);
+            }
+          });
+        }
+      })();
+    </script>
     <!-- Custom JS -->
     <div layout:fragment="scripts"></div>
-</body>
+  </body>
 </html>

--- a/main/resources/templates/readings/new.html
+++ b/main/resources/templates/readings/new.html
@@ -28,7 +28,7 @@
                     <h6 class="m-0 font-weight-bold text-primary">Unos novog očitanja</h6>
                 </div>
                 <div class="card-body">
-                    <form id="newReadingForm" method="post" action="/readings/new" th:object="${newReadingDTO}">
+                    <form id="newReadingForm" method="post" th:action="@{/readings/new}" th:object="${newReadingDTO}">
                         <div class="form-group">
                             <label for="userId">Korisnik</label>
                             <select class="form-control" id="userId" name="userId" th:field="*{userId}" required>
@@ -76,6 +76,7 @@
                             <label for="notes">Napomene</label>
                             <textarea class="form-control" id="notes" name="notes" th:field="*{notes}" rows="3"></textarea>
                         </div>
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                         <button type="submit" class="btn btn-primary" id="submitBtn">Spremi očitanje</button>
                         <a href="/readings" class="btn btn-secondary">Odustani</a>
                     </form>


### PR DESCRIPTION
Enable automatic previous reading fetch, set today's date, and fix new reading submission and validation.

This PR resolves issues with the new reading form by correcting the latest reading retrieval method in the repository, integrating jQuery and CSRF handling for client-side functionality (like date defaulting and AJAX validations), and adding the necessary CSRF token to the form for successful submission.

---
<a href="https://cursor.com/background-agent?bcId=bc-6773b182-72cb-4741-a450-2d66f4bba867">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6773b182-72cb-4741-a450-2d66f4bba867">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

