### PR TITLE
Update water price unit in admin

### DIFF
--- a/main/java/com/vodovod/controller/SettingsController.java
+++ b/main/java/com/vodovod/controller/SettingsController.java
@@ -32,11 +32,11 @@ public class SettingsController {
     }
 
     @PostMapping
-    public String updateSettings(@RequestParam(name = "electricityPricePerKWh") BigDecimal electricityPricePerKWh,
+    public String updateSettings(@RequestParam(name = "waterPricePerM3") BigDecimal waterPricePerM3,
                                  @RequestParam(name = "fixedFee") BigDecimal fixedFee,
                                  @RequestParam(name = "useFixedFee", defaultValue = "false") boolean useFixedFee,
                                  RedirectAttributes redirectAttributes) {
-        settingsService.updateSettings(electricityPricePerKWh, fixedFee, useFixedFee);
+        settingsService.updateSettings(waterPricePerM3, fixedFee, useFixedFee);
         redirectAttributes.addFlashAttribute("successMessage", "Postavke su uspješno spremljene.");
         return "redirect:/settings";
     }

--- a/main/java/com/vodovod/service/SettingsService.java
+++ b/main/java/com/vodovod/service/SettingsService.java
@@ -17,9 +17,9 @@ public class SettingsService {
         return systemSettingsRepository.findTopByOrderByIdAsc().orElseGet(SystemSettings::new);
     }
 
-    public SystemSettings updateSettings(BigDecimal electricityPricePerKWh, BigDecimal fixedFee, boolean useFixedFee) {
+    public SystemSettings updateSettings(BigDecimal waterPricePerM3, BigDecimal fixedFee, boolean useFixedFee) {
         SystemSettings settings = systemSettingsRepository.findTopByOrderByIdAsc().orElseGet(SystemSettings::new);
-        settings.setElectricityPricePerKWh(electricityPricePerKWh);
+        settings.setWaterPricePerM3(waterPricePerM3);
         settings.setFixedFee(fixedFee);
         settings.setUseFixedFee(useFixedFee);
         return systemSettingsRepository.save(settings);

--- a/main/resources/templates/settings/index.html
+++ b/main/resources/templates/settings/index.html
@@ -13,12 +13,12 @@
             <form th:action="@{/settings}" method="post" class="row g-3">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div class="col-md-4">
-                    <label for="electricityPricePerKWh" class="form-label">Cijena električne energije (KM/kWh)</label>
-                    <input type="number" step="0.0001" min="0" class="form-control" id="electricityPricePerKWh" name="electricityPricePerKWh"
-                           th:value="${settings.electricityPricePerKWh}" required>
-                    <div class="form-text">Trenutno važeća cijena električne energije</div>
+                    <label for="waterPricePerM3" class="form-label">Cijena vode (KM/m3)</label>
+                    <input type="number" step="0.01" min="0.01" class="form-control" id="waterPricePerM3" name="waterPricePerM3"
+                           th:value="${settings.waterPricePerM3}" required>
+                    <div class="form-text">Trenutno važeća cijena vode po kubiku</div>
                 </div>
-
+                
                 <div class="col-md-4">
                     <label for="fixedFee" class="form-label">Fiksna naknada (KM)</label>
                     <div class="input-group">
@@ -28,7 +28,7 @@
                     </div>
                     <div id="fixedFeeHelp" class="form-text">Iznos po računu, neovisno o potrošnji</div>
                 </div>
-
+                
                 <div class="col-md-4 d-flex align-items-end">
                     <div class="form-check form-switch">
                         <input class="form-check-input" type="checkbox" id="useFixedFee" name="useFixedFee" th:checked="${settings.useFixedFee}">
@@ -36,7 +36,7 @@
                         <div class="form-text">Ako je isključeno, paušal se ne obračunava.</div>
                     </div>
                 </div>
-
+                
                 <div class="col-12">
                     <button type="submit" class="btn btn-primary">
                         <i class="bi bi-save"></i> Spremi postavke


### PR DESCRIPTION
Replace electricity price with water price (KM/m3) in Admin settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-983e2c0d-8cf6-4a90-b07e-4deafab52fe9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-983e2c0d-8cf6-4a90-b07e-4deafab52fe9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

