### PR TITLE
Generate default reading for new user

### DIFF
--- a/main/java/com/vodovod/config/DataInitializer.java
+++ b/main/java/com/vodovod/config/DataInitializer.java
@@ -5,6 +5,7 @@ import com.vodovod.model.SystemSettings;
 import com.vodovod.model.User;
 import com.vodovod.repository.SystemSettingsRepository;
 import com.vodovod.repository.UserRepository;
+import com.vodovod.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,6 +24,9 @@ public class DataInitializer implements CommandLineRunner {
 
     @Autowired
     private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private UserService userService;
 
     @Override
     public void run(String... args) throws Exception {
@@ -68,14 +72,14 @@ public class DataInitializer implements CommandLineRunner {
             user.setFirstName("Marko");
             user.setLastName("Marković");
             user.setEmail("marko@example.com");
-            user.setPassword(passwordEncoder.encode("user123"));
+            user.setPassword("user123");
             user.setRole(Role.USER);
             user.setMeterNumber("VM001");
             user.setAddress("Test ulica 1, Zagreb");
             user.setPhoneNumber("098/123-456");
             user.setEnabled(true);
             
-            userRepository.save(user);
+            userService.createUser(user);
             System.out.println("✓ Kreiran test korisnik (username: user1, password: user123, meter: VM001)");
         }
     }


### PR DESCRIPTION
Automatically generate a default meter reading (0 value, user creation date) when a new user is created.

This ensures that every new user with a meter number and `ROLE.USER` has an initial meter reading automatically recorded at the time of their creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-14c42a50-a286-45ee-bb2a-28eafce99067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14c42a50-a286-45ee-bb2a-28eafce99067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

