### PR TITLE
Prikaz detaljnih ocitanja pojedinacnog

### DIFF
--- a/main/java/com/vodovod/controller/ReadingsController.java
+++ b/main/java/com/vodovod/controller/ReadingsController.java
@@ -111,6 +111,18 @@ public class ReadingsController {
     }
 
     /**
+     * Detaljni prikaz pojedinačnog očitanja
+     */
+    @GetMapping("/{id}")
+    public String view(@PathVariable Long id, Model model) {
+        MeterReading reading = meterReadingService.findById(id)
+                .orElseThrow(() -> new RuntimeException("Očitanje nije pronađeno"));
+        model.addAttribute("pageTitle", "Pregled očitanja #" + id);
+        model.addAttribute("reading", reading);
+        return "readings/view";
+    }
+
+    /**
      * API endpoint za dohvaćanje prethodnog očitanja korisnika
      */
     @GetMapping("/api/user/{userId}/latest-reading")

--- a/main/java/com/vodovod/service/MeterReadingService.java
+++ b/main/java/com/vodovod/service/MeterReadingService.java
@@ -103,4 +103,11 @@ public class MeterReadingService {
     public List<MeterReading> getReadingsWithoutBill() {
         return meterReadingRepository.findReadingsWithoutBill();
     }
+
+    /**
+     * Dohvaća očitanje po ID-u
+     */
+    public Optional<MeterReading> findById(Long id) {
+        return meterReadingRepository.findById(id);
+    }
 }

--- a/main/resources/templates/readings/view.html
+++ b/main/resources/templates/readings/view.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title th:text="${pageTitle}">Pregled očitanja</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="d-sm-flex align-items-center justify-content-between mb-4">
+        <h1 class="h3 mb-0 text-gray-800" th:text="${pageTitle}">Pregled očitanja</h1>
+        <div>
+            <a href="/readings" class="btn btn-secondary btn-sm">
+                <i class="bi bi-arrow-left"></i> Nazad na listu
+            </a>
+            <a th:href="@{'/users/' + ${reading.user.id}}" class="btn btn-outline-primary btn-sm">
+                <i class="bi bi-person"></i> Korisnik
+            </a>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-lg-8">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Osnovni podaci</h6>
+                </div>
+                <div class="card-body">
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">ID</div>
+                        <div class="col-sm-8" th:text="${reading.id}">1</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Korisnik</div>
+                        <div class="col-sm-8">
+                            <a th:href="@{'/users/' + ${reading.user.id}}" th:text="${reading.user.fullName}">Ime Prezime</a>
+                            <small class="text-muted" th:if="${reading.user.meterNumber}">(<span th:text="${reading.user.meterNumber}"></span>)</small>
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Datum očitanja</div>
+                        <div class="col-sm-8" th:text="${#temporals.format(reading.readingDate, 'dd.MM.yyyy')}">01.01.2025</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Prethodno stanje</div>
+                        <div class="col-sm-8 text-right" th:text="${#numbers.formatDecimal(reading.previousReadingValue, 1, 3) + ' m³'}">0,000 m³</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Novo stanje</div>
+                        <div class="col-sm-8 text-right" th:text="${#numbers.formatDecimal(reading.readingValue, 1, 3) + ' m³'}">0,000 m³</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Potrošnja</div>
+                        <div class="col-sm-8 text-right" th:text="${#numbers.formatDecimal(reading.consumption, 1, 3) + ' m³'}">0,000 m³</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Račun generiran</div>
+                        <div class="col-sm-8">
+                            <span th:if="${reading.billGenerated}" class="badge badge-success">DA</span>
+                            <span th:unless="${reading.billGenerated}" class="badge badge-secondary">NE</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Dodatne informacije</h6>
+                </div>
+                <div class="card-body">
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Adresa</div>
+                        <div class="col-sm-8" th:text="${reading.user.address != null ? reading.user.address : '—'}">—</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Kontakt</div>
+                        <div class="col-sm-8">
+                            <span th:text="${reading.user.phoneNumber != null ? reading.user.phoneNumber : '—'}">—</span>
+                            <span class="text-muted" th:if="${reading.user.email}"> · <span th:text="${reading.user.email}"></span></span>
+                        </div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Unio</div>
+                        <div class="col-sm-8" th:text="${reading.createdBy != null ? reading.createdBy : '—'}">—</div>
+                    </div>
+                    <div class="row mb-3">
+                        <div class="col-sm-4 text-muted">Kreirano</div>
+                        <div class="col-sm-8" th:text="${reading.createdAt != null ? #temporals.format(reading.createdAt, 'dd.MM.yyyy HH:mm') : '—'}">—</div>
+                    </div>
+                    <div class="row">
+                        <div class="col-sm-4 text-muted">Napomene</div>
+                        <div class="col-sm-8">
+                            <pre class="mb-0" style="white-space: pre-wrap;" th:text="${reading.notes != null ? reading.notes : '—'}">—</pre>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-lg-4">
+            <div class="card shadow mb-4">
+                <div class="card-header py-3">
+                    <h6 class="m-0 font-weight-bold text-primary">Korisnik</h6>
+                </div>
+                <div class="card-body">
+                    <div class="mb-2"><strong th:text="${reading.user.fullName}">Ime Prezime</strong></div>
+                    <div class="text-muted small">Broj vodomjera: <span th:text="${reading.user.meterNumber != null ? reading.user.meterNumber : '—'}">—</span></div>
+                    <div class="text-muted small">Adresa: <span th:text="${reading.user.address != null ? reading.user.address : '—'}">—</span></div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
Adds a detailed view for individual meter readings, accessible via the "Pregled" button, to display all associated data, including fields not present in the main table.

---
<a href="https://cursor.com/background-agent?bcId=bc-aff259cb-6570-49a5-961f-06b7e2602881">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-aff259cb-6570-49a5-961f-06b7e2602881">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

