### PR TITLE
Ukloni korisnički ID iz prikaza tablice

### DIFF
--- a/main/resources/templates/users/list.html
+++ b/main/resources/templates/users/list.html
@@ -29,7 +29,6 @@
                 <table class="table table-bordered table-hover">
                     <thead class="table-light">
                         <tr>
-                            <th>ID</th>
                             <th>Korisničko ime</th>
                             <th>Ime i prezime</th>
                             <th>Email</th>
@@ -42,13 +41,12 @@
                     </thead>
                     <tbody>
                         <tr th:if="${#lists.isEmpty(users)}">
-                            <td colspan="9" class="text-center text-muted">
+                            <td colspan="8" class="text-center text-muted">
                                 <i class="bi bi-inbox"></i>
                                 Nema korisnika u sustavu.
                             </td>
                         </tr>
                         <tr th:each="user : ${users}">
-                            <td th:text="${user.id}">#1</td>
                             <td>
                                 <strong th:text="${user.username}">username</strong>
                             </td>


### PR DESCRIPTION
Remove ID column from the users table as it is not required for display.

---
<a href="https://cursor.com/background-agent?bcId=bc-15bd68d5-9e3b-425a-a001-eaefe9844c42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15bd68d5-9e3b-425a-a001-eaefe9844c42">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

