### PR TITLE
Remove due accounts from dashboard

### DIFF
--- a/main/java/com/vodovod/service/DashboardService.java
+++ b/main/java/com/vodovod/service/DashboardService.java
@@ -41,7 +41,8 @@ public class DashboardService {
         stats.setPaidBills(billRepository.countByStatus(BillStatus.PAID));
         stats.setUnpaidBills(
             billRepository.countByStatus(BillStatus.PENDING) +
-            billRepository.countByStatus(BillStatus.PARTIALLY_PAID)
+            billRepository.countByStatus(BillStatus.PARTIALLY_PAID) +
+            billRepository.countByStatus(BillStatus.OVERDUE)
         );
         stats.setOverdueBills(billRepository.findOverdueBills(LocalDate.now()).size());
 
@@ -51,8 +52,10 @@ public class DashboardService {
 
         BigDecimal pendingRevenue = billRepository.sumTotalAmountByStatus(BillStatus.PENDING);
         BigDecimal partiallyPaidRevenue = billRepository.sumTotalAmountByStatus(BillStatus.PARTIALLY_PAID);
+        BigDecimal overdueRevenue = billRepository.sumTotalAmountByStatus(BillStatus.OVERDUE);
         BigDecimal totalPending = (pendingRevenue != null ? pendingRevenue : BigDecimal.ZERO)
-                .add(partiallyPaidRevenue != null ? partiallyPaidRevenue : BigDecimal.ZERO);
+                .add(partiallyPaidRevenue != null ? partiallyPaidRevenue : BigDecimal.ZERO)
+                .add(overdueRevenue != null ? overdueRevenue : BigDecimal.ZERO);
         stats.setPendingRevenue(totalPending);
 
         // Statistike očitanja

--- a/main/resources/templates/dashboard/index.html
+++ b/main/resources/templates/dashboard/index.html
@@ -67,28 +67,10 @@
                 </div>
             </div>
         </div>
-
-        <!-- Dospješni računi -->
-        <div class="col-xl-3 col-md-6 mb-4">
-            <div class="card border-left-danger shadow h-100 py-2">
-                <div class="card-body">
-                    <div class="row no-gutters align-items-center">
-                        <div class="col mr-2">
-                            <div class="text-xs font-weight-bold text-danger text-uppercase mb-1">
-                                Dospješni Računi
-                            </div>
-                            <div class="h5 mb-0 font-weight-bold text-gray-800" th:text="${stats.overdueBills}">0</div>
-                        </div>
-                        <div class="col-auto">
-                            <i class="bi bi-clock fs-2 text-danger"></i>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            
         </div>
-    </div>
-
-    <!-- Financial Overview -->
+        
+        <!-- Financial Overview -->
     <div class="row mb-4">
         <div class="col-xl-6 col-lg-6">
             <div class="card shadow mb-4">


### PR DESCRIPTION
Remove 'Overdue Bills' dashboard widget and include overdue bills in 'Unpaid' statistics.

The user requested to remove the "Dospješni računi" (Overdue Bills) information from the dashboard and to count such bills as "Neplaćene" (Unpaid). This PR implements that by removing the dedicated widget and adjusting the `unpaidBills` count and `pendingRevenue` calculation to include `OVERDUE` status.

---
<a href="https://cursor.com/background-agent?bcId=bc-384b9032-08a1-4c8a-8bef-a1dea5af658e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-384b9032-08a1-4c8a-8bef-a1dea5af658e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

