### PR TITLE
Fix user update functionality

### DIFF
--- a/main/java/com/vodovod/model/User.java
+++ b/main/java/com/vodovod/model/User.java
@@ -33,7 +33,6 @@ public class User {
     @Column(unique = true)
     private String email;
     
-    @NotBlank(message = "Lozinka je obavezna")
     private String password;
     
     @Enumerated(EnumType.STRING)

--- a/main/resources/templates/users/form.html
+++ b/main/resources/templates/users/form.html
@@ -28,6 +28,7 @@
                 <div class="card-body">
                     <form th:action="${user.id != null ? '/users/' + user.id + '/edit' : '/users/new'}" 
                           th:object="${user}" method="post">
+                        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                         
                         <!-- Basic Information -->
                         <div class="row">

--- a/main/resources/templates/users/list.html
+++ b/main/resources/templates/users/list.html
@@ -97,6 +97,7 @@
                                             <li th:if="${user.enabled}">
                                                 <form th:action="@{'/users/' + ${user.id} + '/delete'}" method="post" class="d-inline"
                                                       onsubmit="return confirm('Jeste li sigurni da želite onemogućiti ovog korisnika?')">
+                                                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                                     <button type="submit" class="dropdown-item text-warning">
                                                         <i class="bi bi-x-circle"></i>
                                                         Onemogući
@@ -105,6 +106,7 @@
                                             </li>
                                             <li th:unless="${user.enabled}">
                                                 <form th:action="@{'/users/' + ${user.id} + '/enable'}" method="post" class="d-inline">
+                                                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                                     <button type="submit" class="dropdown-item text-success">
                                                         <i class="bi bi-check-circle"></i>
                                                         Omogući

--- a/main/resources/templates/users/view.html
+++ b/main/resources/templates/users/view.html
@@ -235,6 +235,7 @@
                         
                         <form th:if="${user.enabled}" th:action="@{'/users/' + ${user.id} + '/delete'}" method="post"
                               onsubmit="return confirm('Jeste li sigurni da želite onemogućiti ovog korisnika?')">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <button type="submit" class="btn btn-warning w-100">
                                 <i class="bi bi-x-circle"></i>
                                 Onemogući korisnika
@@ -242,6 +243,7 @@
                         </form>
                         
                         <form th:unless="${user.enabled}" th:action="@{'/users/' + ${user.id} + '/enable'}" method="post">
+                            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <button type="submit" class="btn btn-success w-100">
                                 <i class="bi bi-check-circle"></i>
                                 Omogući korisnika


### PR DESCRIPTION
Enable user updates by adding CSRF tokens to forms and removing password blank validation.

User updates were failing because Spring Security blocked POST requests due to missing CSRF tokens, and the password field's `@NotBlank` validation prevented saving when the password was not re-entered.

---
<a href="https://cursor.com/background-agent?bcId=bc-d15a818c-2082-45d1-ab12-7fd6e1a797cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d15a818c-2082-45d1-ab12-7fd6e1a797cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

