### PR TITLE
Admin panel for water pricing and fees

### DIFF
--- a/main/resources/templates/settings/index.html
+++ b/main/resources/templates/settings/index.html
@@ -12,19 +12,14 @@
         <div class="card-body">
             <form th:action="@{/settings}" method="post" class="row g-3">
                 <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
-                <div class="col-md-4">
+                <div class="col-md-6">
                     <label for="waterPricePerM3" class="form-label">Cijena vode (KM/m3)</label>
                     <input type="number" step="0.01" min="0.01" class="form-control" id="waterPricePerM3" name="waterPricePerM3"
                            th:value="${settings.waterPricePerM3}" required>
                     <div class="form-text">Trenutno važeća cijena vode po kubiku</div>
                 </div>
                 
-                <div class="col-md-4">
-                    <div class="form-check form-switch mb-3">
-                        <input class="form-check-input" type="checkbox" id="useFixedFee" name="useFixedFee" th:checked="${settings.useFixedFee}">
-                        <label class="form-check-label fw-semibold" for="useFixedFee">Uključi fiksnu naknadu</label>
-                        <div class="form-text">Ako je isključeno, paušal se ne obračunava.</div>
-                    </div>
+                <div class="col-md-6">
                     <label for="fixedFee" class="form-label">Fiksna naknada (KM)</label>
                     <div class="input-group">
                         <input type="number" step="0.01" min="0" class="form-control" id="fixedFee" name="fixedFee"
@@ -34,11 +29,19 @@
                     <div id="fixedFeeHelp" class="form-text">Iznos po računu, neovisno o potrošnji</div>
                 </div>
                 
-                <div class="col-md-6">
+                <div class="col-12">
                     <label for="accountNumber" class="form-label">Broj bankovnog računa za uplate (IBAN)</label>
                     <input type="text" class="form-control" id="accountNumber" name="accountNumber"
                            th:value="${settings.accountNumber}" placeholder="npr. HR1234567890123456789" required>
                     <div class="form-text">Ovaj broj računa bit će prikazan na ispisu računa.</div>
+                </div>
+                
+                <div class="col-12">
+                    <div class="form-check form-switch mb-3">
+                        <input class="form-check-input" type="checkbox" id="useFixedFee" name="useFixedFee" th:checked="${settings.useFixedFee}">
+                        <label class="form-check-label fw-semibold" for="useFixedFee">Uključi fiksnu naknadu</label>
+                        <div class="form-text">Ako je isključeno, paušal se ne obračunava.</div>
+                    </div>
                 </div>
                 
                 <div class="col-12">


### PR DESCRIPTION
Rearrange admin panel settings layout for water price, fixed fee, account number, and fixed fee toggle.

---
<a href="https://cursor.com/background-agent?bcId=bc-ca7a68f7-4a11-478b-873b-5eabc0546daa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ca7a68f7-4a11-478b-873b-5eabc0546daa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

