### PR TITLE
Update invoice status and color coding

### DIFF
--- a/main/resources/templates/bills/index.html
+++ b/main/resources/templates/bills/index.html
@@ -73,7 +73,10 @@
                                     <td th:text="${b.issueDate}"></td>
                                     <td th:text="${b.dueDate}"></td>
                                     <td th:text="${#numbers.formatDecimal(b.totalAmount, 1, 'COMMA', 2, 'POINT')}"></td>
-                                    <td th:text="${b.status.displayName}"></td>
+                                    <td>
+                                        <span th:text="${b.status.displayName}"
+                                              th:classappend="${b.status == T(com.vodovod.model.BillStatus).PAID} ? 'badge bg-success' : (${b.status == T(com.vodovod.model.BillStatus).PARTIALLY_PAID} ? 'badge bg-warning text-dark' : (${b.status == T(com.vodovod.model.BillStatus).PENDING} ? 'badge bg-danger' : 'badge bg-secondary'))"></span>
+                                    </td>
                                     <td class="text-center">
                                         <a th:href="@{'/bills/' + ${b.id} + '/pdf'}" class="btn btn-outline-secondary btn-sm" title="Preuzmi PDF">
                                             <i class="bi bi-filetype-pdf"></i>


### PR DESCRIPTION
Add colored Bootstrap badges for invoice statuses in the bills table to improve visual distinction.

---
<a href="https://cursor.com/background-agent?bcId=bc-a85458c5-42f8-4f7d-8dfb-6b10ec587570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a85458c5-42f8-4f7d-8dfb-6b10ec587570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

