### PR TITLE
Rewrite pdf invoice generation to match old template

### DIFF
--- a/main/java/com/vodovod/controller/BillsController.java
+++ b/main/java/com/vodovod/controller/BillsController.java
@@ -39,7 +39,8 @@ public class BillsController {
     @Autowired
     private SettingsService settingsService;
 
-    private final BillPdfService billPdfService = new BillPdfService();
+    @Autowired
+    private BillPdfService billPdfService;
 
     @GetMapping
     public String index(@RequestParam(value = "userId", required = false) Long userId, Model model) {


### PR DESCRIPTION
Reimplement PDF invoice generation to match the legacy application's layout using a PDF template and integrate data from the current database.

This change addresses the user's request to replicate the exact visual appearance of PDF invoices from the old application. It switches from programmatic PDF generation to stamping data onto a pre-designed `/tamplate_invoice.pdf` and fetches all necessary data (client info, readings, financial details, debt/credit) directly from the application's database via injected repositories. The template file `main/resources/tamplate_invoice.pdf` must be present for PDF generation to succeed.

---
<a href="https://cursor.com/background-agent?bcId=bc-88a2cb10-0ada-4c8c-8a98-5e4032d65ae3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-88a2cb10-0ada-4c8c-8a98-5e4032d65ae3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

