### PR TITLE
Fix fetching and displaying all payments

### DIFF
--- a/main/java/com/vodovod/controller/PaymentsController.java
+++ b/main/java/com/vodovod/controller/PaymentsController.java
@@ -3,6 +3,7 @@ package com.vodovod.controller;
 import com.vodovod.model.Bill;
 import com.vodovod.model.User;
 import com.vodovod.repository.BillRepository;
+import com.vodovod.repository.PaymentRepository;
 import com.vodovod.service.PaymentService;
 import com.vodovod.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,9 +32,13 @@ public class PaymentsController {
     @Autowired
     private PaymentService paymentService;
 
+    @Autowired
+    private PaymentRepository paymentRepository;
+
     @GetMapping
     public String index(Model model) {
         model.addAttribute("pageTitle", "Plaćanja");
+        model.addAttribute("payments", paymentRepository.findAllOrderByPaymentDateDesc());
         return "payments/index";
     }
     

--- a/main/resources/templates/payments/index.html
+++ b/main/resources/templates/payments/index.html
@@ -38,8 +38,29 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr>
+                                <tr th:if="${#lists.isEmpty(payments)}">
                                     <td colspan="8" class="text-center">Nema podataka za prikaz</td>
+                                </tr>
+                                <tr th:each="p : ${payments}">
+                                    <td th:text="${p.id}">-</td>
+                                    <td>
+                                        <span th:text="${p.bill != null ? p.bill.billNumber : '-'}"></span>
+                                    </td>
+                                    <td th:text="${p.user != null ? p.user.fullName : '-'}">-</td>
+                                    <td th:text="${p.paymentDate}">-</td>
+                                    <td th:text="${#numbers.formatDecimal(p.amount, 1, 'COMMA', 2, 'POINT')}">-</td>
+                                    <td th:text="${p.paymentMethod != null ? p.paymentMethod : '-'}">-</td>
+                                    <td>
+                                        <span th:if="${p.bill == null}" class="badge bg-info text-dark">Avans</span>
+                                        <span th:if="${p.bill != null}" class="badge bg-secondary">Za račun</span>
+                                    </td>
+                                    <td>
+                                        <div class="btn-group btn-group-sm" role="group">
+                                            <a th:if="${p.bill != null}" th:href="@{'/bills/' + ${p.bill.id} + '/pdf'}" class="btn btn-outline-secondary" title="Račun PDF">
+                                                <i class="bi bi-filetype-pdf"></i>
+                                            </a>
+                                        </div>
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
Adds fetching and displaying of all payments on the payments page.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3e6ea3e-17d0-43bd-abaf-53ffd2e85572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b3e6ea3e-17d0-43bd-abaf-53ffd2e85572">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

