### PR TITLE
Fix thymeleaf template parsing errors after filter addition

### DIFF
--- a/main/resources/templates/bills/index.html
+++ b/main/resources/templates/bills/index.html
@@ -28,8 +28,8 @@
                 <option th:selected="${selectedUserId == null}" value="">Svi korisnici</option>
                 <option th:each="u : ${users}"
                         th:value="${u.id}"
-                        th:text="${u.fullName} + ' (' + ${u.meterNumber} + ')'"
-                        th:selected="${selectedUserId} == ${u.id}">
+                        th:text="${u.fullName + ' (' + u.meterNumber + ')'}"
+                        th:selected="${selectedUserId == u.id}">
                 </option>
             </select>
         </div>
@@ -72,10 +72,10 @@
                             </thead>
                             <tbody>
                                 <tr th:if="${#lists.isEmpty(bills)}">
-                                    <td colspan="7" class="text-center">Nema podataka za prikaz</td>
+                                    <td colspan="8" class="text-center">Nema podataka za prikaz</td>
                                 </tr>
                                 <tr th:each="b : ${bills}">
-                                    <td th:text="${b.billNumber} ?: '-'">-</td>
+                                    <td th:text="${b.billNumber != null ? b.billNumber : '-'}">-</td>
                                     <td th:text="${b.user.fullName}"></td>
                                     <td>
                                         <span th:text="${b.periodFrom}"></span> - <span th:text="${b.periodTo}"></span>
@@ -88,7 +88,7 @@
                                               th:classappend="${b.status == T(com.vodovod.model.BillStatus).PAID} ? 'badge bg-success' : (${b.status == T(com.vodovod.model.BillStatus).PARTIALLY_PAID} ? 'badge bg-warning text-dark' : (${b.status == T(com.vodovod.model.BillStatus).PENDING} ? 'badge bg-danger' : 'badge bg-secondary'))"></span>
                                     </td>
                                     <td class="text-center">
-                                        <a th:href="@{'/bills/' + ${b.id} + '/pdf'}" class="btn btn-outline-secondary btn-sm" title="Preuzmi PDF">
+                                        <a th:href="@{/bills/{id}/pdf(id=${b.id})}" class="btn btn-outline-secondary btn-sm" title="Preuzmi PDF">
                                             <i class="bi bi-filetype-pdf"></i>
                                         </a>
                                     </td>

--- a/main/resources/templates/dashboard/index.html
+++ b/main/resources/templates/dashboard/index.html
@@ -193,7 +193,7 @@
                             <tbody>
                                 <tr th:each="ub : ${stats.userBalances}">
                                     <td>
-                                        <a th:href="@{'/users/' + ${ub.userId}}" th:text="${ub.fullName}">Ime Prezime</a>
+                                        <a th:href="@{/users/{id}(id=${ub.userId})}" th:text="${ub.fullName}">Ime Prezime</a>
                                     </td>
                                     <td th:text="${ub.meterNumber}">-</td>
                                     <td class="text-end" th:text="${#numbers.formatDecimal(ub.amount, 1, 2)} + ' KM'">0.00 KM</td>

--- a/main/resources/templates/layout/main.html
+++ b/main/resources/templates/layout/main.html
@@ -5,7 +5,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:text="${pageTitle} + ' - Vodovod Management'">Vodovod Management</title>
+    <title th:text="${pageTitle != null ? pageTitle + ' - Vodovod Management' : 'Vodovod Management'}">Vodovod Management</title>
     
     <!-- CSRF Meta -->
     <meta name="_csrf" th:content="${_csrf.token}" />

--- a/main/resources/templates/payments/index.html
+++ b/main/resources/templates/payments/index.html
@@ -23,8 +23,8 @@
                 <option th:selected="${selectedUserId == null}" value="">Svi korisnici</option>
                 <option th:each="u : ${users}"
                         th:value="${u.id}"
-                        th:text="${u.fullName} + ' (' + ${u.meterNumber} + ')'"
-                        th:selected="${selectedUserId} == ${u.id}">
+                        th:text="${u.fullName + ' (' + u.meterNumber + ')'}"
+                        th:selected="${selectedUserId == u.id}">
                 </option>
             </select>
         </div>
@@ -84,7 +84,7 @@
                                     </td>
                                     <td>
                                         <div class="btn-group btn-group-sm" role="group">
-                                            <a th:if="${p.bill != null}" th:href="@{'/bills/' + ${p.bill.id} + '/pdf'}" class="btn btn-outline-secondary" title="Račun PDF">
+                                            <a th:if="${p.bill != null}" th:href="@{/bills/{id}/pdf(id=${p.bill.id})}" class="btn btn-outline-secondary" title="Račun PDF">
                                                 <i class="bi bi-filetype-pdf"></i>
                                             </a>
                                         </div>

--- a/main/resources/templates/payments/new.html
+++ b/main/resources/templates/payments/new.html
@@ -25,7 +25,7 @@
                             <label for="userId">Korisnik</label>
                             <select class="form-control" id="userId" name="userId" required>
                                 <option value="">Odaberite korisnika</option>
-                                <option th:each="u : ${users}" th:value="${u.id}" th:text="${u.fullName} + ' (' + ${u.meterNumber} + ')'" />
+                                <option th:each="u : ${users}" th:value="${u.id}" th:text="${u.fullName + ' (' + u.meterNumber + ')'}" />
                             </select>
                         </div>
                         <div class="form-group">

--- a/main/resources/templates/readings/index.html
+++ b/main/resources/templates/readings/index.html
@@ -31,8 +31,8 @@
                 <option th:selected="${selectedUserId == null}" value="">Svi korisnici</option>
                 <option th:each="u : ${users}"
                         th:value="${u.id}"
-                        th:text="${u.fullName} + ' (' + ${u.meterNumber} + ')'"
-                        th:selected="${selectedUserId} == ${u.id}">
+                        th:text="${u.fullName + ' (' + u.meterNumber + ')'}"
+                        th:selected="${selectedUserId == u.id}">
                 </option>
             </select>
         </div>
@@ -84,7 +84,7 @@
                                     <td class="text-right" th:text="${#numbers.formatDecimal(reading.readingValue, 1, 3) + ' m³'}"></td>
                                     <td class="text-right" th:text="${#numbers.formatDecimal(reading.consumption, 1, 3) + ' m³'}"></td>
                                     <td class="text-center">
-                                        <a th:href="@{'/readings/' + ${reading.id}}" class="btn btn-info btn-sm" title="Pregled detalja">
+                                        <a th:href="@{/readings/{id}(id=${reading.id})}" class="btn btn-info btn-sm" title="Pregled detalja">
                                             <i class="bi bi-eye"></i> Pregled
                                         </a>
                                     </td>

--- a/main/resources/templates/readings/view.html
+++ b/main/resources/templates/readings/view.html
@@ -13,7 +13,7 @@
             <a href="/readings" class="btn btn-secondary btn-sm">
                 <i class="bi bi-arrow-left"></i> Nazad na listu
             </a>
-            <a th:href="@{'/users/' + ${reading.user.id}}" class="btn btn-outline-primary btn-sm">
+            <a th:href="@{/users/{id}(id=${reading.user.id})}" class="btn btn-outline-primary btn-sm">
                 <i class="bi bi-person"></i> Korisnik
             </a>
         </div>
@@ -33,7 +33,7 @@
                     <div class="row mb-3">
                         <div class="col-sm-4 text-muted">Korisnik</div>
                         <div class="col-sm-8">
-                            <a th:href="@{'/users/' + ${reading.user.id}}" th:text="${reading.user.fullName}">Ime Prezime</a>
+                            <a th:href="@{/users/{id}(id=${reading.user.id})}" th:text="${reading.user.fullName}">Ime Prezime</a>
                             <small class="text-muted" th:if="${reading.user.meterNumber}">(<span th:text="${reading.user.meterNumber}"></span>)</small>
                         </div>
                     </div>

--- a/main/resources/templates/users/list.html
+++ b/main/resources/templates/users/list.html
@@ -82,10 +82,10 @@
                             <td th:text="${#temporals.format(user.createdAt, 'dd.MM.yyyy HH:mm')}">01.01.2024 10:00</td>
                             <td>
                                 <div class="btn-group" role="group">
-                                    <a th:href="@{'/users/' + ${user.id}}" class="btn btn-sm btn-outline-info" title="Pregled">
+                                    <a th:href="@{/users/{id}(id=${user.id})}" class="btn btn-sm btn-outline-info" title="Pregled">
                                         <i class="bi bi-eye"></i>
                                     </a>
-                                    <a th:href="@{'/users/' + ${user.id} + '/edit'}" class="btn btn-sm btn-outline-primary" title="Uredi">
+                                    <a th:href="@{/users/{id}/edit(id=${user.id})}" class="btn btn-sm btn-outline-primary" title="Uredi">
                                         <i class="bi bi-pencil"></i>
                                     </a>
                                     <div class="btn-group" role="group">
@@ -95,7 +95,7 @@
                                         </button>
                                         <ul class="dropdown-menu">
                                             <li th:if="${user.enabled}">
-                                                <form th:action="@{'/users/' + ${user.id} + '/delete'}" method="post" class="d-inline"
+                                                <form th:action="@{/users/{id}/delete(id=${user.id})}" method="post" class="d-inline"
                                                       onsubmit="return confirm('Jeste li sigurni da želite onemogućiti ovog korisnika?')">
                                                     <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                                                     <button type="submit" class="dropdown-item text-warning">

--- a/main/resources/templates/users/view.html
+++ b/main/resources/templates/users/view.html
@@ -34,7 +34,7 @@
             </span>
         </h1>
         <div>
-            <a th:href="@{'/users/' + ${user.id} + '/edit'}" class="btn btn-primary">
+            <a th:href="@{/users/{id}/edit(id=${user.id})}" class="btn btn-primary">
                 <i class="bi bi-pencil"></i>
                 Uredi
             </a>
@@ -228,12 +228,12 @@
                 </div>
                 <div class="card-body">
                     <div class="d-grid gap-2">
-                        <a th:href="@{'/users/' + ${user.id} + '/edit'}" class="btn btn-primary">
+                        <a th:href="@{/users/{id}/edit(id=${user.id})}" class="btn btn-primary">
                             <i class="bi bi-pencil"></i>
                             Uredi korisnika
                         </a>
                         
-                        <form th:if="${user.enabled}" th:action="@{'/users/' + ${user.id} + '/delete'}" method="post"
+                        <form th:if="${user.enabled}" th:action="@{/users/{id}/delete(id=${user.id})}" method="post"
                               onsubmit="return confirm('Jeste li sigurni da želite onemogućiti ovog korisnika?')">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <button type="submit" class="btn btn-warning w-100">
@@ -242,7 +242,7 @@
                             </button>
                         </form>
                         
-                        <form th:unless="${user.enabled}" th:action="@{'/users/' + ${user.id} + '/enable'}" method="post">
+                        <form th:unless="${user.enabled}" th:action="@{/users/{id}/enable(id=${user.id})}" method="post">
                             <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
                             <button type="submit" class="btn btn-success w-100">
                                 <i class="bi bi-check-circle"></i>


### PR DESCRIPTION
Fix Thymeleaf parsing errors by correcting expression syntax and URL building across multiple templates.

---
<a href="https://cursor.com/background-agent?bcId=bc-28251971-9075-40f0-992f-5199cc268e95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-28251971-9075-40f0-992f-5199cc268e95">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

