### PR TITLE
Show user-specific menu after login

### DIFF
--- a/main/java/com/vodovod/config/SecurityConfig.java
+++ b/main/java/com/vodovod/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
             )
             .formLogin(form -> form
                 .loginPage("/login")
-                .defaultSuccessUrl("/dashboard", true)
+                .defaultSuccessUrl("/", true)
                 .failureUrl("/login?error=true")
                 .permitAll()
             )

--- a/main/java/com/vodovod/controller/AuthController.java
+++ b/main/java/com/vodovod/controller/AuthController.java
@@ -10,12 +10,12 @@ public class AuthController {
 
     @GetMapping("/login")
     public String login(Authentication authentication) {
-        // Ako je korisnik već prijavljen, preusmjeri ga na dashboard
+        // Ako je korisnik već prijavljen, preusmjeri ga na odgovarajuću početnu stranicu
         if (authentication != null && authentication.isAuthenticated()) {
             if (authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
                 return "redirect:/dashboard";
             } else {
-                return "redirect:/my-bills";
+                return "redirect:/my-account";
             }
         }
         return "login";
@@ -27,7 +27,7 @@ public class AuthController {
             if (authentication.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_ADMIN"))) {
                 return "redirect:/dashboard";
             } else {
-                return "redirect:/my-bills";
+                return "redirect:/my-account";
             }
         }
         return "redirect:/login";

--- a/main/java/com/vodovod/controller/MyAccountController.java
+++ b/main/java/com/vodovod/controller/MyAccountController.java
@@ -47,6 +47,7 @@ public class MyAccountController {
         User user = userOpt.get();
         model.addAttribute("pageTitle", "Moj Račun");
         model.addAttribute("user", user);
+        model.addAttribute("activeMenu", "my-account");
         
         return "account/profile";
     }

--- a/main/resources/templates/account/profile.html
+++ b/main/resources/templates/account/profile.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="hr" xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/main}">
+<head>
+    <title>Moj račun</title>
+</head>
+<body>
+<div layout:fragment="content">
+    <div class="row">
+        <div class="col-md-6">
+            <div class="card shadow mb-4">
+                <div class="card-header">
+                    <h6 class="m-0 font-weight-bold text-primary">
+                        <i class="bi bi-person"></i>
+                        Moj račun
+                    </h6>
+                </div>
+                <div class="card-body">
+                    <div class="mb-2">
+                        <strong>Ime i prezime:</strong> <span th:text="${user.fullName}">Ime Prezime</span>
+                    </div>
+                    <div class="mb-2">
+                        <strong>Korisničko ime:</strong> <span th:text="${user.username}">korisnik</span>
+                    </div>
+                    <div class="mb-2">
+                        <strong>Email:</strong> <span th:text="${user.email}">email@example.com</span>
+                    </div>
+                    <div th:if="${user.phoneNumber}" class="mb-2">
+                        <strong>Telefon:</strong> <span th:text="${user.phoneNumber}">+385 99 123 456</span>
+                    </div>
+                    <div th:if="${user.address}" class="mb-2">
+                        <strong>Adresa:</strong> <span th:text="${user.address}">Adresa 1</span>
+                    </div>
+                    <div th:if="${user.meterNumber}" class="mb-2">
+                        <strong>Broj vodomjera:</strong> <span class="badge bg-info" th:text="${user.meterNumber}">VM001</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card shadow mb-4">
+                <div class="card-header">
+                    <h6 class="m-0 font-weight-bold text-secondary">
+                        <i class="bi bi-lock"></i>
+                        Sigurnost
+                    </h6>
+                </div>
+                <div class="card-body">
+                    <p class="text-muted small">Za promjenu lozinke obratite se administratoru sustava.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/main/resources/templates/layout/main.html
+++ b/main/resources/templates/layout/main.html
@@ -52,7 +52,7 @@
     <!-- Navigation Bar -->
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
         <div class="container-fluid">
-            <a class="navbar-brand" href="/dashboard">
+            <a class="navbar-brand" href="/">
                 <i class="bi bi-droplet-fill"></i>
                 Vodovod Management
             </a>
@@ -137,10 +137,10 @@
                         <!-- User Menu -->
                         <div sec:authorize="hasRole('USER')">
                             <li class="nav-item">
-                                <a class="nav-link" th:classappend="${activeMenu == 'my-bills'} ? 'active'" 
-                                   href="/my-bills">
-                                    <i class="bi bi-receipt"></i>
-                                    Moji Računi
+                                <a class="nav-link" th:classappend="${activeMenu == 'my-account'} ? 'active'" 
+                                   href="/my-account">
+                                    <i class="bi bi-person"></i>
+                                    Moj račun
                                 </a>
                             </li>
                         </div>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,11 @@
             <groupId>nz.net.ultraq.thymeleaf</groupId>
             <artifactId>thymeleaf-layout-dialect</artifactId>
         </dependency>
+        <!-- Added: Thymeleaf Spring Security extras -->
+        <dependency>
+            <groupId>org.thymeleaf.extras</groupId>
+            <artifactId>thymeleaf-extras-springsecurity6</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
Implement role-based menu visibility and login redirection to show regular users only 'My Account' and redirect them there after login, while admins retain full access.

---
<a href="https://cursor.com/background-agent?bcId=bc-d18c737e-2e6a-4f1d-b3fb-02320008b3c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d18c737e-2e6a-4f1d-b3fb-02320008b3c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

