### PR TITLE
Storniraj unos ocitanja kao da nikad nije postojao

### DIFF
--- a/main/java/com/vodovod/controller/ReadingsController.java
+++ b/main/java/com/vodovod/controller/ReadingsController.java
@@ -151,6 +151,23 @@ public class ReadingsController {
     }
 
     /**
+     * Storno očitanja - briše očitanje i rekalkulira lanac kao da nije postojalo
+     */
+    @PostMapping("/{id}/storno")
+    public String storno(@PathVariable Long id,
+                         RedirectAttributes redirect,
+                         Authentication auth) {
+        try {
+            meterReadingService.stornoReading(id, auth != null ? auth.getName() : "system");
+            redirect.addFlashAttribute("successMessage", "Očitanje je stornirano.");
+        } catch (Exception ex) {
+            redirect.addFlashAttribute("errorMessage", "Greška pri stornu: " + ex.getMessage());
+            return "redirect:/readings/" + id;
+        }
+        return "redirect:/readings";
+    }
+
+    /**
      * API endpoint za dohvaćanje prethodnog očitanja korisnika
      */
     @GetMapping("/api/user/{userId}/latest-reading")

--- a/main/java/com/vodovod/repository/MeterReadingRepository.java
+++ b/main/java/com/vodovod/repository/MeterReadingRepository.java
@@ -46,4 +46,8 @@ public interface MeterReadingRepository extends JpaRepository<MeterReading, Long
     // Date range filtering across all users
     List<MeterReading> findByReadingDateGreaterThanEqualOrderByReadingDateDesc(LocalDate startDate);
     List<MeterReading> findByReadingDateLessThanEqualOrderByReadingDateDesc(LocalDate endDate);
+
+    // Previous/next helpers around a given date for a user
+    Optional<MeterReading> findTopByUserAndReadingDateBeforeOrderByReadingDateDesc(User user, LocalDate readingDate);
+    List<MeterReading> findByUserAndReadingDateAfterOrderByReadingDateAsc(User user, LocalDate readingDate);
 }

--- a/main/java/com/vodovod/service/MeterReadingService.java
+++ b/main/java/com/vodovod/service/MeterReadingService.java
@@ -134,4 +134,40 @@ public class MeterReadingService {
             return getReadingsByUser(user);
         }
     }
+
+    /**
+     * Storno očitanja: potpuno uklanja očitanje i rekalkulira lanac narednih očitanja
+     * tako da stanje bude kao da očitanje nikada nije postojalo.
+     */
+    public void stornoReading(Long readingId, String cancelledBy) {
+        MeterReading reading = meterReadingRepository.findById(readingId)
+                .orElseThrow(() -> new IllegalArgumentException("Očitanje nije pronađeno"));
+
+        User user = reading.getUser();
+
+        // Dohvati prethodno očitanje (po datumu) kako bismo ga koristili kao nova polazna osnova
+        Optional<MeterReading> previousOpt = meterReadingRepository
+                .findTopByUserAndReadingDateBeforeOrderByReadingDateDesc(user, reading.getReadingDate());
+
+        BigDecimal newBase = previousOpt.map(MeterReading::getReadingValue).orElse(BigDecimal.ZERO);
+
+        // Dohvati sva naredna očitanja i rekalkuliraj im previous/consumption
+        List<MeterReading> subsequent = meterReadingRepository
+                .findByUserAndReadingDateAfterOrderByReadingDateAsc(user, reading.getReadingDate());
+
+        BigDecimal lastBase = newBase;
+        for (MeterReading mr : subsequent) {
+            mr.setPreviousReadingValue(lastBase);
+            mr.calculateConsumption();
+            // Ukloni oznaku generiranog računa jer se lanac promijenio (oprezan pristup)
+            if (mr.isBillGenerated()) {
+                mr.setBillGenerated(false);
+            }
+            lastBase = mr.getReadingValue();
+            meterReadingRepository.save(mr);
+        }
+
+        // Na kraju izbriši ciljano očitanje
+        meterReadingRepository.delete(reading);
+    }
 }

--- a/main/resources/templates/readings/view.html
+++ b/main/resources/templates/readings/view.html
@@ -16,6 +16,12 @@
             <a th:href="@{/users/{id}(id=${reading.user.id})}" class="btn btn-outline-primary btn-sm">
                 <i class="bi bi-person"></i> Korisnik
             </a>
+            <form th:action="@{/readings/{id}/storno(id=${reading.id})}" method="post" style="display:inline" onsubmit="return confirm('Jeste li sigurni da želite stornirati ovo očitanje? Ova akcija je nepovratna.');">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                <button type="submit" class="btn btn-danger btn-sm">
+                    <i class="bi bi-x-circle"></i> Storno
+                </button>
+            </form>
         </div>
     </div>
 


### PR DESCRIPTION
Add 'storno' (cancellation) functionality for meter readings to allow users to remove an entry as if it never existed, recalculating subsequent readings.

---
<a href="https://cursor.com/background-agent?bcId=bc-172073af-4689-44a3-b8c6-809184d6ebdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-172073af-4689-44a3-b8c6-809184d6ebdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

