### PR TITLE
Fix navigation overflow on mobile

### DIFF
--- a/main/resources/templates/layout/main.html
+++ b/main/resources/templates/layout/main.html
@@ -64,7 +64,7 @@
                         <i class="bi bi-person-fill"></i>
                         <span sec:authentication="name">Korisnik</span>
                     </a>
-                    <ul class="dropdown-menu">
+                    <ul class="dropdown-menu dropdown-menu-end">
                         <li><a class="dropdown-item" href="/my-account">
                             <i class="bi bi-person"></i> Moj račun
                         </a></li>


### PR DESCRIPTION
Add `dropdown-menu-end` class to the user dropdown to prevent it from overflowing off-screen.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9b3f64b-15ef-4ac4-9245-a3741fc15542">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9b3f64b-15ef-4ac4-9245-a3741fc15542">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

