### PR TITLE
Unify titles on user readings, bills, and payments

### DIFF
--- a/main/java/com/vodovod/controller/BillsController.java
+++ b/main/java/com/vodovod/controller/BillsController.java
@@ -52,6 +52,20 @@ public class BillsController {
             Model model) {
         model.addAttribute("pageTitle", "Računi");
         model.addAttribute("activeMenu", "bills");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/bills/new",
+                        "cssClass", "btn btn-primary btn-sm",
+                        "label", "Novi račun",
+                        "id", "btn-new-bill"
+                ),
+                java.util.Map.of(
+                        "url", "#",
+                        "cssClass", "btn btn-success btn-sm",
+                        "label", "Automatski generiraj",
+                        "id", "btn-generate"
+                )
+        ));
         List<User> users = userService.getActiveWaterUsers();
         model.addAttribute("users", users);
 
@@ -76,6 +90,14 @@ public class BillsController {
     public String newBill(Model model) {
         model.addAttribute("pageTitle", "Novi račun");
         model.addAttribute("activeMenu", "bills");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/bills",
+                        "cssClass", "btn btn-outline-secondary btn-sm",
+                        "label", "Natrag",
+                        "id", "btn-back"
+                )
+        ));
         model.addAttribute("users", userService.getActiveWaterUsers());
         model.addAttribute("settings", settingsService.getCurrentSettingsOrNew());
         return "bills/new";

--- a/main/java/com/vodovod/controller/PaymentsController.java
+++ b/main/java/com/vodovod/controller/PaymentsController.java
@@ -43,6 +43,14 @@ public class PaymentsController {
                         @RequestParam(value = "endDate", required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate) {
         model.addAttribute("pageTitle", "Plaćanja");
         model.addAttribute("activeMenu", "payments");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/payments/new",
+                        "cssClass", "btn btn-primary btn-sm",
+                        "label", "Novo plaćanje",
+                        "id", "btn-new-payment"
+                )
+        ));
         // Populate users for filter dropdown
         model.addAttribute("users", userService.getActiveWaterUsers());
         model.addAttribute("selectedUserId", userId);
@@ -67,6 +75,15 @@ public class PaymentsController {
     @GetMapping("/new")
     public String newPayment(Model model) {
         model.addAttribute("pageTitle", "Novo plaćanje");
+        model.addAttribute("activeMenu", "payments");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/payments",
+                        "cssClass", "btn btn-outline-secondary btn-sm",
+                        "label", "Natrag",
+                        "id", "btn-back"
+                )
+        ));
         model.addAttribute("users", userService.getActiveWaterUsers());
         return "payments/new";
     }

--- a/main/java/com/vodovod/controller/ReadingsController.java
+++ b/main/java/com/vodovod/controller/ReadingsController.java
@@ -61,6 +61,15 @@ public class ReadingsController {
             readings = meterReadingService.getAllReadingsByDateRange(fromDate, toDate);
         }
         model.addAttribute("pageTitle", "Očitanja");
+        model.addAttribute("activeMenu", "readings");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/readings/new",
+                        "cssClass", "btn btn-primary btn-sm",
+                        "label", "Novo očitanje",
+                        "id", "btn-new-reading"
+                )
+        ));
         model.addAttribute("readings", readings);
         // Add users for filter dropdown (only active water users)
         model.addAttribute("users", userService.getActiveWaterUsers());
@@ -73,6 +82,15 @@ public class ReadingsController {
     @GetMapping("/new")
     public String newReading(Model model) {
         model.addAttribute("pageTitle", "Novo očitanje");
+        model.addAttribute("activeMenu", "readings");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/readings",
+                        "cssClass", "btn btn-outline-secondary btn-sm",
+                        "label", "Natrag",
+                        "id", "btn-back"
+                )
+        ));
         NewReadingDTO dto = new NewReadingDTO();
         dto.setReadingDate(LocalDate.now());
         model.addAttribute("newReadingDTO", dto);
@@ -146,6 +164,21 @@ public class ReadingsController {
         MeterReading reading = meterReadingService.findById(id)
                 .orElseThrow(() -> new RuntimeException("Očitanje nije pronađeno"));
         model.addAttribute("pageTitle", "Pregled očitanja #" + id);
+        model.addAttribute("activeMenu", "readings");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/readings",
+                        "cssClass", "btn btn-secondary btn-sm",
+                        "label", "Nazad na listu",
+                        "id", "btn-back"
+                ),
+                java.util.Map.of(
+                        "url", "/users/" + reading.getUser().getId(),
+                        "cssClass", "btn btn-outline-primary btn-sm",
+                        "label", "Korisnik",
+                        "id", "btn-user"
+                )
+        ));
         model.addAttribute("reading", reading);
         return "readings/view";
     }

--- a/main/java/com/vodovod/controller/UserController.java
+++ b/main/java/com/vodovod/controller/UserController.java
@@ -29,6 +29,14 @@ public class UserController {
         
         model.addAttribute("pageTitle", "Korisnici");
         model.addAttribute("activeMenu", "users");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/users/new",
+                        "cssClass", "btn btn-primary btn-sm",
+                        "label", "Dodaj Korisnika",
+                        "id", "btn-new-user"
+                )
+        ));
         model.addAttribute("users", users);
         
         return "users/list";
@@ -41,6 +49,14 @@ public class UserController {
         
         model.addAttribute("pageTitle", "Novi Korisnik");
         model.addAttribute("activeMenu", "users");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/users",
+                        "cssClass", "btn btn-outline-secondary btn-sm",
+                        "label", "Natrag",
+                        "id", "btn-back"
+                )
+        ));
         model.addAttribute("user", user);
         model.addAttribute("roles", Role.values());
         
@@ -91,6 +107,20 @@ public class UserController {
 
         model.addAttribute("pageTitle", "Pregled Korisnika");
         model.addAttribute("activeMenu", "users");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/users/" + id + "/edit",
+                        "cssClass", "btn btn-primary btn-sm",
+                        "label", "Uredi",
+                        "id", "btn-edit-user"
+                ),
+                java.util.Map.of(
+                        "url", "/users",
+                        "cssClass", "btn btn-outline-secondary btn-sm",
+                        "label", "Povratak",
+                        "id", "btn-back"
+                )
+        ));
         model.addAttribute("user", userOpt.get());
         
         return "users/view";
@@ -106,6 +136,14 @@ public class UserController {
 
         model.addAttribute("pageTitle", "Uredi Korisnika");
         model.addAttribute("activeMenu", "users");
+        model.addAttribute("pageActions", java.util.List.of(
+                java.util.Map.of(
+                        "url", "/users",
+                        "cssClass", "btn btn-outline-secondary btn-sm",
+                        "label", "Povratak",
+                        "id", "btn-back"
+                )
+        ));
         model.addAttribute("user", userOpt.get());
         model.addAttribute("roles", Role.values());
         

--- a/main/resources/templates/bills/index.html
+++ b/main/resources/templates/bills/index.html
@@ -7,18 +7,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <!-- Page Heading -->
-    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-        <h1 class="h3 mb-0 text-gray-800">Računi</h1>
-        <div class="d-flex gap-2">
-            <button id="btn-generate" class="btn btn-success btn-sm">
-                <i class="bi bi-magic"></i> Automatski generiraj račune
-            </button>
-            <a href="/bills/new" class="btn btn-primary btn-sm">
-                <i class="bi bi-plus-circle"></i> Novi račun
-            </a>
-        </div>
-    </div>
+    
 
     <!-- Filters -->
     <form class="row g-3 mb-3" method="get" action="/bills" id="filters-form">

--- a/main/resources/templates/bills/new.html
+++ b/main/resources/templates/bills/new.html
@@ -12,12 +12,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-        <h1 class="h3 mb-0 text-gray-800">Novi račun</h1>
-        <div>
-            <a href="/bills" class="btn btn-outline-secondary btn-sm"><i class="bi bi-arrow-left"></i> Natrag</a>
-        </div>
-    </div>
+    
 
     <div class="card">
         <div class="card-body">

--- a/main/resources/templates/layout/main.html
+++ b/main/resources/templates/layout/main.html
@@ -215,7 +215,7 @@
                     <h1 class="h2" th:text="${pageTitle}">Page Title</h1>
                     <div class="btn-toolbar mb-2 mb-md-0" th:if="${pageActions}">
                         <div class="btn-group me-2" th:each="action : ${pageActions}">
-                            <a th:href="${action.url}" th:class="${action.cssClass}" th:text="${action.label}"></a>
+                            <a th:href="${action.url}" th:class="${action.cssClass}" th:attr="id=${action.id}" th:text="${action.label}"></a>
                         </div>
                     </div>
                 </div>

--- a/main/resources/templates/payments/index.html
+++ b/main/resources/templates/payments/index.html
@@ -7,13 +7,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <!-- Page Heading -->
-    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-        <h1 class="h3 mb-0 text-gray-800">Plaćanja</h1>
-        <a href="/payments/new" class="btn btn-primary btn-sm">
-            <i class="bi bi-plus-circle"></i> Novo plaćanje
-        </a>
-    </div>
+    
 
     <!-- Filters -->
     <form class="row g-3 mb-3" method="get" th:action="@{/payments}" id="filters-form">

--- a/main/resources/templates/payments/new.html
+++ b/main/resources/templates/payments/new.html
@@ -7,10 +7,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <!-- Page Heading -->
-    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-        <h1 class="h3 mb-0 text-gray-800">Novo plaćanje</h1>
-    </div>
+    
 
     <!-- Content Row -->
     <div class="row">

--- a/main/resources/templates/readings/index.html
+++ b/main/resources/templates/readings/index.html
@@ -15,13 +15,7 @@
         </button>
     </div>
 
-    <!-- Page Heading -->
-    <div class="d-sm-flex align-items-center justify-content-between mb-3">
-        <h1 class="h3 mb-0 text-gray-800">Očitanja</h1>
-        <a href="/readings/new" class="btn btn-primary btn-sm">
-            <i class="bi bi-plus-circle"></i> Novo očitanje
-        </a>
-    </div>
+    
 
     <!-- Filters -->
     <form class="row g-3 mb-3" method="get" action="/readings" id="filters-form">

--- a/main/resources/templates/readings/new.html
+++ b/main/resources/templates/readings/new.html
@@ -15,10 +15,7 @@
         </button>
     </div>
 
-    <!-- Page Heading -->
-    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-        <h1 class="h3 mb-0 text-gray-800">Novo očitanje</h1>
-    </div>
+    
 
     <!-- Content Row -->
     <div class="row">

--- a/main/resources/templates/readings/view.html
+++ b/main/resources/templates/readings/view.html
@@ -7,17 +7,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <div class="d-sm-flex align-items-center justify-content-between mb-4">
-        <h1 class="h3 mb-0 text-gray-800" th:text="${pageTitle}">Pregled očitanja</h1>
-        <div>
-            <a href="/readings" class="btn btn-secondary btn-sm">
-                <i class="bi bi-arrow-left"></i> Nazad na listu
-            </a>
-            <a th:href="@{/users/{id}(id=${reading.user.id})}" class="btn btn-outline-primary btn-sm">
-                <i class="bi bi-person"></i> Korisnik
-            </a>
-        </div>
-    </div>
+    
 
     <div class="row">
         <div class="col-lg-8">

--- a/main/resources/templates/users/list.html
+++ b/main/resources/templates/users/list.html
@@ -7,14 +7,7 @@
 </head>
 <body>
 <div layout:fragment="content">
-    <!-- Page Actions -->
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1 class="h3 mb-0">Korisnici</h1>
-        <a href="/users/new" class="btn btn-primary btn-sm">
-            <i class="bi bi-person-plus"></i>
-            Dodaj Korisnika
-        </a>
-    </div>
+    
 
     <!-- Users Table -->
     <div class="card shadow">

--- a/main/resources/templates/users/view.html
+++ b/main/resources/templates/users/view.html
@@ -16,34 +16,7 @@
         </ol>
     </nav>
 
-    <!-- Header -->
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1 class="h3 mb-0">
-            <span th:text="${user.fullName}">Ime Prezime</span>
-            <span th:if="${user.role.name() == 'ADMIN'}" class="badge bg-danger ms-2">
-                <i class="bi bi-shield-check"></i>
-                Administrator
-            </span>
-            <span th:if="${user.role.name() == 'USER'}" class="badge bg-primary ms-2">
-                <i class="bi bi-person"></i>
-                Korisnik
-            </span>
-            <span th:if="${!user.enabled}" class="badge bg-secondary ms-2">
-                <i class="bi bi-x-circle"></i>
-                Neaktivan
-            </span>
-        </h1>
-        <div>
-            <a th:href="@{/users/{id}/edit(id=${user.id})}" class="btn btn-primary">
-                <i class="bi bi-pencil"></i>
-                Uredi
-            </a>
-            <a href="/users" class="btn btn-secondary">
-                <i class="bi bi-arrow-left"></i>
-                Povratak
-            </a>
-        </div>
-    </div>
+    
 
     <div class="row">
         <!-- User Information -->


### PR DESCRIPTION
Consolidate page titles and move action buttons to a single header for Readings, Bills, Payments, and Users pages.

This change eliminates duplicate `<h1>` headings on several pages by centralizing title and action button rendering in the main layout, ensuring a consistent header experience across the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-c9171fc0-cd20-4ade-911e-e513fdee9dff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c9171fc0-cd20-4ade-911e-e513fdee9dff">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

