### PR TITLE
Add cancel functionality for unused readings

### DIFF
--- a/main/java/com/vodovod/controller/ReadingsController.java
+++ b/main/java/com/vodovod/controller/ReadingsController.java
@@ -151,6 +151,26 @@ public class ReadingsController {
     }
 
     /**
+     * Storniranje (cancel) očitanja koje nije korišteno za račun.
+     */
+    @PostMapping("/{id}/cancel")
+    public String cancel(@PathVariable Long id, RedirectAttributes redirectAttributes) {
+        try {
+            MeterReading reading = meterReadingService.findById(id)
+                    .orElseThrow(() -> new RuntimeException("Očitanje nije pronađeno"));
+            if (reading.isBillGenerated()) {
+                redirectAttributes.addFlashAttribute("errorMessage", "Ovo očitanje je korišteno za račun i ne može se stornirati.");
+                return "redirect:/readings";
+            }
+            meterReadingService.cancelReading(id);
+            redirectAttributes.addFlashAttribute("successMessage", "Očitanje je uspješno stornirano.");
+        } catch (Exception e) {
+            redirectAttributes.addFlashAttribute("errorMessage", "Greška pri storniranju očitanja: " + e.getMessage());
+        }
+        return "redirect:/readings";
+    }
+
+    /**
      * API endpoint za dohvaćanje prethodnog očitanja korisnika
      */
     @GetMapping("/api/user/{userId}/latest-reading")

--- a/main/java/com/vodovod/model/MeterReading.java
+++ b/main/java/com/vodovod/model/MeterReading.java
@@ -37,6 +37,9 @@ public class MeterReading {
     
     @Column(name = "bill_generated")
     private boolean billGenerated = false; // Da li je generiran račun za ovo očitanje
+
+    @Column(name = "cancelled")
+    private boolean cancelled = false; // Da li je očitanje stornirano (ne koristi se u izračunima)
     
     private String notes; // Napomene
     
@@ -115,6 +118,14 @@ public class MeterReading {
     
     public void setBillGenerated(boolean billGenerated) {
         this.billGenerated = billGenerated;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
     }
     
     public String getNotes() {

--- a/main/java/com/vodovod/repository/MeterReadingRepository.java
+++ b/main/java/com/vodovod/repository/MeterReadingRepository.java
@@ -15,19 +15,23 @@ public interface MeterReadingRepository extends JpaRepository<MeterReading, Long
     
     List<MeterReading> findByUserOrderByReadingDateDesc(User user);
     
-    @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user ORDER BY mr.readingDate DESC")
+    @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user AND mr.cancelled = false ORDER BY mr.readingDate DESC")
     List<MeterReading> findByUserOrderByReadingDateDescending(User user);
     
     Optional<MeterReading> findTopByUserOrderByReadingDateDesc(User user);
+    Optional<MeterReading> findTopByUserAndCancelledFalseOrderByReadingDateDesc(User user);
     
-    @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user AND mr.readingDate = :readingDate")
+    @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user AND mr.readingDate = :readingDate AND mr.cancelled = false")
     Optional<MeterReading> findByUserAndReadingDate(User user, LocalDate readingDate);
     
-    @Query("SELECT mr FROM MeterReading mr WHERE mr.billGenerated = false")
+    @Query("SELECT mr FROM MeterReading mr WHERE mr.billGenerated = false AND mr.cancelled = false")
     List<MeterReading> findReadingsWithoutBill();
     
-    @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user AND mr.billGenerated = false ORDER BY mr.readingDate ASC")
+    @Query("SELECT mr FROM MeterReading mr WHERE mr.user = :user AND mr.billGenerated = false AND mr.cancelled = false ORDER BY mr.readingDate ASC")
     List<MeterReading> findUnbilledReadingsByUser(User user);
+    
+    // Ascending order per user (used for recalculation after cancellation)
+    List<MeterReading> findByUserOrderByReadingDateAsc(User user);
     
     @Query("SELECT COUNT(mr) FROM MeterReading mr WHERE mr.readingDate BETWEEN :startDate AND :endDate")
     long countByReadingDateBetween(LocalDate startDate, LocalDate endDate);

--- a/main/resources/templates/readings/index.html
+++ b/main/resources/templates/readings/index.html
@@ -57,6 +57,7 @@
                                     <th>Prethodno stanje</th>
                                     <th>Novo stanje</th>
                                     <th>Potrošnja</th>
+                                    <th>Status</th>
                                     <th>Akcije</th>
                                 </tr>
                             </thead>
@@ -73,10 +74,24 @@
                                     <td class="text-right" th:text="${#numbers.formatDecimal(reading.previousReadingValue, 1, 3) + ' m³'}"></td>
                                     <td class="text-right" th:text="${#numbers.formatDecimal(reading.readingValue, 1, 3) + ' m³'}"></td>
                                     <td class="text-right" th:text="${#numbers.formatDecimal(reading.consumption, 1, 3) + ' m³'}"></td>
+                                    <td>
+                                        <span th:if="${reading.cancelled}" class="badge bg-secondary">Stornirano</span>
+                                        <span th:if="${!reading.cancelled and reading.billGenerated}" class="badge bg-success">Račun generiran</span>
+                                        <span th:if="${!reading.cancelled and !reading.billGenerated}" class="badge bg-info text-dark">Aktivno</span>
+                                    </td>
                                     <td class="text-center">
                                         <a th:href="@{/readings/{id}(id=${reading.id})}" class="btn btn-info btn-sm" title="Pregled detalja">
                                             <i class="bi bi-eye"></i> Pregled
                                         </a>
+                                        <form th:if="${!reading.billGenerated and !reading.cancelled}"
+                                              th:action="@{/readings/{id}/cancel(id=${reading.id})}"
+                                              method="post" class="d-inline"
+                                              onsubmit="return confirm('Jeste li sigurni da želite stornirati ovo očitanje?');">
+                                            <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                                            <button type="submit" class="btn btn-outline-danger btn-sm" title="Storniraj očitanje">
+                                                <i class="bi bi-x-circle"></i> Storniraj
+                                            </button>
+                                        </form>
                                     </td>
                                 </tr>
                             </tbody>

--- a/main/resources/templates/readings/view.html
+++ b/main/resources/templates/readings/view.html
@@ -54,13 +54,23 @@
                         <div class="col-sm-8 text-right" th:text="${#numbers.formatDecimal(reading.consumption, 1, 3) + ' m³'}">0,000 m³</div>
                     </div>
                     <div class="row mb-3">
-                        <div class="col-sm-4 text-muted">Račun generiran</div>
+                        <div class="col-sm-4 text-muted">Status</div>
                         <div class="col-sm-8">
-                            <span th:if="${reading.billGenerated}" class="badge badge-success">DA</span>
-                            <span th:unless="${reading.billGenerated}" class="badge badge-secondary">NE</span>
+                            <span th:if="${reading.cancelled}" class="badge bg-secondary">Stornirano</span>
+                            <span th:if="${!reading.cancelled and reading.billGenerated}" class="badge bg-success">Račun generiran</span>
+                            <span th:if="${!reading.cancelled and !reading.billGenerated}" class="badge bg-info text-dark">Aktivno</span>
                         </div>
                     </div>
                 </div>
+            </div>
+            <div class="mb-3" th:if="${!reading.billGenerated and !reading.cancelled}">
+                <form th:action="@{/readings/{id}/cancel(id=${reading.id})}" method="post"
+                      onsubmit="return confirm('Jeste li sigurni da želite stornirati ovo očitanje?');">
+                    <input th:if="${_csrf != null}" type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
+                    <button type="submit" class="btn btn-outline-danger btn-sm">
+                        <i class="bi bi-x-circle"></i> Storniraj očitanje
+                    </button>
+                </form>
             </div>
 
             <div class="card shadow mb-4">


### PR DESCRIPTION
Implement meter reading cancellation to allow voiding unbilled readings and ensure subsequent readings are correctly recalculated.

When a reading is cancelled, it is marked as such and excluded from all calculations and validations. The system automatically re-calculates the `previousReadingValue` and `consumption` for all subsequent uncancelled readings for the same user, ensuring data consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-01c2ec44-00d3-4d61-9369-73abd2ae7065">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01c2ec44-00d3-4d61-9369-73abd2ae7065">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

